### PR TITLE
Add fusepy to list of dependencies for ktdumper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 On Ubuntu you can install the dependencies with:
 
 ```
-sudo apt install python3-usb python3-tqdm gcc-arm-none-eabi fusepy
+sudo apt install python3-usb python3-tqdm gcc-arm-none-eabi python3-fusepy
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 On Ubuntu you can install the dependencies with:
 
 ```
-sudo apt install python3-usb python3-tqdm gcc-arm-none-eabi
+sudo apt install python3-usb python3-tqdm gcc-arm-none-eabi fusepy
 ```
 
 ## Usage


### PR DESCRIPTION
The current version of ktdumper won't run unless fusepy is installed.