### PR TITLE
Fix N902i

### DIFF
--- a/ktdumper/devices.py
+++ b/ktdumper/devices.py
@@ -125,8 +125,8 @@ DEVICES = [
     }, payload_base=0x10000000, onenand_addr=0x06000000),
 
     Device("n902i", 0x0409, 0x014c, {
-        "dump_nor": NecMemoryDumper(base=0x0, size=MB(128)),
-    }, payload_base=0x80000000, onenand_addr=0x10000000, quirks=SLOW_READ),
+        "dump_nor": NecMemoryDumper(base=0x08000000, size=MB(96)),
+    }, payload_base=0x80000000, quirks=SLOW_READ),
 
     Device("n702id", 0x0409, 0x0168, {
         "dump_nor": NecMemoryDumper(base=0x0, size=MB(128)),


### PR DESCRIPTION
Fixes:
1. NOR dump base = 0x08000000 or else the script will not work
2. Size is 96MB
3. onenand_addr removed because we cannot yet dump any nand