### PR TITLE
Add a note that notifies no JAM dumping

### DIFF
--- a/ktdumper/dump/fujitsu/fujitsu_java_dumper_alternative.py
+++ b/ktdumper/dump/fujitsu/fujitsu_java_dumper_alternative.py
@@ -46,6 +46,10 @@ class FujitsuJavaDumperAlternative(FujitsuProtocol):
 
     def execute(self, dev, output):
         super().execute(dev, output)
+        
+        print("-" * 80)
+        print("NOTE: This phone dump will require rebuilding of JAM files. No JAM files will be dumped using this method.")
+        print("-" * 80)
 
         print("Retrieving the database")
         db = self.retrieve_file("D:\\Sanremo\\Java\\FJJAM.DB")


### PR DESCRIPTION
For users who will dump phones using `dump_java_alternative`. So, that they properly install keitai-tools to process the dump.