### PR TITLE
Add args to func signatures in payloads

### DIFF
--- a/ktdumper/payload/dump_nand_lp_and_send.c
+++ b/ktdumper/payload/dump_nand_lp_and_send.c
@@ -5,7 +5,7 @@ void start() {
     uint8_t *command = (void*)%usb_command%;
     uint8_t *data = (void*)%usb_data%; // comes from cmd_read
     uint8_t *datasz = (void*)%usb_datasz%; // also from cmd_read
-    void (*respfunc)() = (void*)%usb_respfunc%;
+    void (*respfunc)(int, int) = (void*)%usb_respfunc%;
     uint16_t *scratchbuf16 = (void*)(%base%+0x1000);
 
     volatile uint16_t *nand_cmd = (void*)%nand_cmd%;

--- a/ktdumper/payload/dump_nand_sp_and_send.c
+++ b/ktdumper/payload/dump_nand_sp_and_send.c
@@ -5,7 +5,7 @@ void start() {
     uint8_t *command = (void*)%usb_command%;
     uint8_t *data = (void*)%usb_data%; // comes from cmd_read
     uint8_t *datasz = (void*)%usb_datasz%; // also from cmd_read
-    void (*respfunc)() = (void*)%usb_respfunc%;
+    void (*respfunc)(int, int) = (void*)%usb_respfunc%;
     uint16_t *scratchbuf16 = (void*)(%base%+0x1000);
 
     volatile uint16_t *nand_cmd = (void*)%nand_cmd%;

--- a/ktdumper/payload/emmc_dump.c
+++ b/ktdumper/payload/emmc_dump.c
@@ -8,9 +8,9 @@ void start() {
     uint8_t *data = (void*)%usb_data%; // comes from cmd_read
     uint8_t *datasz = (void*)%usb_datasz%; // also from cmd_read
     uint8_t *tmpbuf = (void*)(%base%+0x800);
-    void (*respfunc)() = (void*)%usb_respfunc%;
+    void (*respfunc)(int, int) = (void*)%usb_respfunc%;
 
-    int (*emmc_read_and_dcache)() = (void*)(%emmc_read_and_dcache%);
+    int (*emmc_read_and_dcache)(uint32_t, uint32_t, uint32_t, uint8_t*) = (void*)(%emmc_read_and_dcache%);
 
     uint32_t page = (command[10] << 0) | (command[11] << 8) | (command[12] << 16) | (command[13] << 24);
     if (emmc_read_and_dcache(0, page * PAGES_PER_CMD, PAGES_PER_CMD, tmpbuf) != 0)

--- a/ktdumper/payload/emmc_rw.c
+++ b/ktdumper/payload/emmc_rw.c
@@ -7,10 +7,10 @@ void start() {
     uint8_t *data = (void*)%usb_data%;
     uint8_t *datasz = (void*)%usb_datasz%;
     uint8_t *tmpbuf = (void*)(%base%+0x800);
-    void (*respfunc)() = (void*)%usb_respfunc%;
+    void (*respfunc)(int, int) = (void*)%usb_respfunc%;
 
-    int (*emmc_read_and_dcache)() = (void*)(%emmc_read_and_dcache%);
-    int (*emmc_inv_dcache_and_write)() = (void*)(%emmc_inv_dcache_and_write%);
+    int (*emmc_read_and_dcache)(uint32_t, uint32_t, uint32_t, uint8_t*) = (void*)(%emmc_read_and_dcache%);
+    int (*emmc_inv_dcache_and_write)(uint32_t, uint32_t, uint32_t, uint8_t*) = (void*)(%emmc_inv_dcache_and_write%);
 
     uint8_t direction = command[10]; /* 0=read, 1=write */
     uint32_t page = (command[11] << 0) | (command[12] << 8) | (command[13] << 16) | (command[14] << 24);

--- a/ktdumper/payload/g1_payload.c
+++ b/ktdumper/payload/g1_payload.c
@@ -12,7 +12,7 @@ void dis_int(void);
 
 int (*usb_reset)() = (void*)KT_usb_reset;
 int (*usb_getch)() = (void*)KT_usb_getch;
-int (*usb_send)() = (void*)KT_usb_send;
+int (*usb_send)(void*, size_t) = (void*)KT_usb_send;
 int (*usb_send_commit)() = (void*)KT_usb_send_commit;
 
 void send(void *buf, size_t sz) {

--- a/ktdumper/payload/nec_payload_v2.c
+++ b/ktdumper/payload/nec_payload_v2.c
@@ -3,8 +3,8 @@
 
 #include "lib/payload.c"
 
-int (*payload_receiver)() = (void*)KT_usb_receive;
-int (*respfunc_send_ep)() = (void*)KT_usb_send;
+int (*payload_receiver)(uint32_t*, uint8_t*) = (void*)KT_usb_receive;
+int (*respfunc_send_ep)(size_t, uint8_t*) = (void*)KT_usb_send;
 
 uint32_t payload_sz_pre, payload_sz, resp_sz;
 uint8_t payload_pre[0x100];

--- a/ktdumper/payload/nec_usb_sender.h
+++ b/ktdumper/payload/nec_usb_sender.h
@@ -3,7 +3,7 @@
 #define USB_SEND(addr, sz) { \
     uint8_t *_data = (void*)KT_usb_data; \
     uint8_t *_datasz = (void*)KT_usb_datasz; \
-    void (*respfunc)() = (void*)KT_usb_respfunc; \
+    void (*respfunc)(int, int) = (void*)KT_usb_respfunc; \
 \
     uint8_t *_inbuf = (void*)addr; \
 \

--- a/ktdumper/payload/onenand_fast.c
+++ b/ktdumper/payload/onenand_fast.c
@@ -8,7 +8,7 @@ void start() {
     uint8_t *data = (void*)KT_usb_data; // comes from cmd_read
     uint16_t *data16 = (void*)KT_usb_data;
     uint8_t *datasz = (void*)KT_usb_datasz; // also from cmd_read
-    void (*respfunc)() = (void*)KT_usb_respfunc;
+    void (*respfunc)(int, int) = (void*)KT_usb_respfunc;
 
     volatile uint16_t *onenand_REG_START_ADDRESS1 = (volatile uint16_t *)(ONENAND + 2*0xF100);
     volatile uint16_t *onenand_REG_START_ADDRESS2 = (volatile uint16_t *)(ONENAND + 2*0xF101);

--- a/ktdumper/payload/pipl_payload_v2.c
+++ b/ktdumper/payload/pipl_payload_v2.c
@@ -3,8 +3,8 @@
 
 #include "lib/payload.c"
 
-int (*payload_receiver)() = (void*)KT_usb_receive;
-int (*respfunc_send_ep)() = (void*)KT_usb_send;
+int (*payload_receiver)(uint32_t*, uint8_t*) = (void*)KT_usb_receive;
+int (*respfunc_send_ep)(size_t, uint8_t*) = (void*)KT_usb_send;
 
 uint32_t payload_sz_pre, payload_sz, resp_sz;
 uint8_t payload_pre[0x100];

--- a/ktdumper/payload/sh_srec_v2.c
+++ b/ktdumper/payload/sh_srec_v2.c
@@ -5,7 +5,7 @@
 void dis_int();
 
 int (*usb_getch)() = (void*)KT_usb_getch;
-int (*usb_send)() = (void*)KT_usb_send;
+int (*usb_send)(void*, size_t) = (void*)KT_usb_send;
 int (*usb_send_commit)() = (void*)KT_usb_send_commit;
 
 size_t resp_sz;

--- a/ktdumper/payload/sony_v2.c
+++ b/ktdumper/payload/sony_v2.c
@@ -5,7 +5,7 @@
 void dis_int();
 
 int (*recv_ch)() = (void*)KT_recv_ch;
-int (*usb_send)() = (void*)KT_usb_send;
+int (*usb_send)(void*, size_t) = (void*)KT_usb_send;
 
 size_t resp_sz;
 


### PR DESCRIPTION
This fixes compile errors on some (modern gcc?) crosscompilers's such as:
error: too many arguments to function 'usb_send'; expected 0, have 2

NOTE: Only sh_srec_v2.c was tested on F-03C as i lack the rest of devices, i tried to guess the args types
the best i could based on the code