### PR TITLE
New maker command in srec exploit

### DIFF
--- a/ktdumper/dump/sh/sh_srec_exploit.py
+++ b/ktdumper/dump/sh/sh_srec_exploit.py
@@ -50,12 +50,8 @@ class ShSrecExploitCommon(Dumper):
             print("data dump => {}".format(data.hex()))
         assert len(data) == sz
         return data
-
-    def execute(self, dev, output):
-        self.output = output
-
-        print("Enter maker mode...")
-
+    
+    def set_ep_mode(self, dev):
         # validate support for mode =0xC0
         data = bytearray(dev.ctrl_transfer(0x41, 0x62, 0x00, 0, b"\x02\xC0"))
         dev.read(0x81, 256)
@@ -64,10 +60,34 @@ class ShSrecExploitCommon(Dumper):
         dev.ctrl_transfer(0x41, 0x60, 0xC0, 0)
         dev.read(0x81, 256)
 
-        # enter maker mode
-        dev.write(3, bytes.fromhex("FF 56 55 42 00 03 C1 01 00 FE"))
+    def execute(self, dev, output):
+        self.output = output
+        vid=dev.idVendor
+        pid=dev.idProduct
 
-        time.sleep(0.5)
+        # enter maker mode so we can send srec command
+        print("Enter maker mode...")
+        self.set_ep_mode(dev)
+        dev.write(3, bytes.fromhex("FF 56 55 42 00 03 C1 01 01 FE"))
+
+        # wait for reboot if in normal mode (those booted with debug cable will enter without reboot)
+        print("Waiting for maker mode...")
+        time.sleep(20)
+
+        dev = None
+        while True:
+            dev = usb.core.find(idVendor=vid, idProduct=pid)
+            if dev is not None:
+                break
+
+            if dev is None:
+                print("Waiting for maker mode...")
+                time.sleep(1)
+            else:
+                break
+            
+        # dev may been reopened, set ep mode
+        self.set_ep_mode(dev)
 
         print("Enter srec mode...")
         dev.write(3, bytes.fromhex("FF 55 56 42 00 01 01 FE"))


### PR DESCRIPTION
Use new maker command in srec exploit version to allow entering maker mode without debug cable, the enter maker command works on F-03C and SH-01C where I tested.
Devices booted with debug cable still enter maker mode fine.

The SHMobile G1 exploit version also has maker command but I can't test myself. simply applying the same changes should work there if command is the same.
    
Credits to Yuu for casually dropping this version that works in normal symbian mode and non debug cable!
